### PR TITLE
Fixed ref name of the tag that triggered the workflow run to more stable github.ref_name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ name: Build & Release (Zephyr 4.2 – NUCLEO-F767ZI – Optimized)
 # Tag syntax: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-branches-and-tags
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*.*.*'
 
@@ -136,6 +134,7 @@ jobs:
   ###############################################################################
   release:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Get pushed tag
         id: version
         run: |
-          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
       ###########################################################################
       # System deps


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow. The change updates how the pushed tag name is extracted, switching from manual string manipulation to using the built-in `github.ref_name` variable for fixing the error.