### PR TITLE
support global west in build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,12 +30,12 @@ foreach ($arg in $args) {
     }
 }
 
-if (-not (Test-Path $venvActivate)) {
-    Write-Host "Virtualenv activation script not found: $venvActivate"
+if (Test-Path $venvActivate) {
+    & $venvActivate
+} elseif (-not (Get-Command west -ErrorAction SilentlyContinue)) {
+    Write-Host "west not found. Install west or create $workspace\.venv."
     exit 1
 }
-
-& $venvActivate
 
 Set-Location $projectPath
 Write-Host "Building K2-Zephyr for $boardLabel..."

--- a/build.sh
+++ b/build.sh
@@ -39,8 +39,13 @@ done
 echo "Setting up Zephyr environment..."
 cd ~/zephyrproject || exit 1
 
-# shellcheck source=/dev/null
-source .venv/bin/activate
+if [[ -f .venv/bin/activate ]]; then
+    # shellcheck source=/dev/null
+    source .venv/bin/activate
+elif ! command -v west >/dev/null 2>&1; then
+    echo "west not found. Install west or create ~/zephyrproject/.venv." >&2
+    exit 1
+fi
 
 echo "Building K2-Zephyr project for ${board_label}..."
 cd ~/zephyrproject/K2-Zephyr || exit 1


### PR DESCRIPTION
This lets the build script use the workspace venv when it exists, or fall back to west from PATH for pipx/global installs.

Verified with ./build.sh --h7.