### PR TITLE
wait for ota confirmation

### DIFF
--- a/tools/k2-ota.ps1
+++ b/tools/k2-ota.ps1
@@ -71,6 +71,43 @@ function Get-SlotHash {
     return $null
 }
 
+function Test-HashActiveConfirmed {
+    param(
+        [string]$Text,
+        [string]$Hash
+    )
+
+    $inSlot = $false
+    $foundHash = $false
+    $active = $false
+    $confirmed = $false
+
+    foreach ($line in ($Text -split "\r?\n")) {
+        if ($line -match "^\s*image=") {
+            if ($inSlot -and $foundHash -and $active -and $confirmed) {
+                return $true
+            }
+            $inSlot = $true
+            $foundHash = $false
+            $active = $false
+            $confirmed = $false
+            continue
+        }
+
+        if ($inSlot -and $line -match "^\s*flags:\s*(.*)") {
+            $flags = $Matches[1] -split "\s+"
+            $active = $flags -contains "active"
+            $confirmed = $flags -contains "confirmed"
+        }
+
+        if ($inSlot -and $line -match "^\s*hash:\s*([0-9a-fA-F]+)") {
+            $foundHash = $Matches[1].ToLowerInvariant() -eq $Hash.ToLowerInvariant()
+        }
+    }
+
+    return $inSlot -and $foundHash -and $active -and $confirmed
+}
+
 $script:McumgrBin = Find-Mcumgr
 
 if (-not (Test-Path $Image)) {
@@ -121,13 +158,20 @@ Write-Host "Waiting for MCU to come back..."
 $deadline = (Get-Date).AddSeconds($PollSeconds)
 while ((Get-Date) -lt $deadline) {
     try {
-        Write-Host (Invoke-Mcumgr image list)
-        exit 0
+        $finalList = Invoke-Mcumgr image list
+        Write-Host $finalList
+        if (Test-HashActiveConfirmed -Text $finalList -Hash $testHash) {
+            Write-Host "Uploaded image is active and confirmed."
+            exit 0
+        }
+        Write-Host "MCU responded, waiting for uploaded image to become active confirmed..."
     } catch {
         Start-Sleep -Seconds 2
+        continue
     }
+    Start-Sleep -Seconds 2
 }
 
-Write-Warning "MCU did not respond to MCUmgr within ${PollSeconds}s after reset."
-Write-Warning "Check power, Ethernet link, and the direct-link network profile."
+Write-Warning "Uploaded image did not become active confirmed within ${PollSeconds}s after reset."
+Write-Warning "Check power, Ethernet link, MCUmgr image state, and serial logs."
 exit 1

--- a/tools/k2-ota.sh
+++ b/tools/k2-ota.sh
@@ -117,6 +117,35 @@ slot_hash() {
     '
 }
 
+is_hash_active_confirmed() {
+    local hash="$1"
+    awk -v hash="$hash" '
+        /^[[:space:]]*image=/ {
+            if (in_slot && found_hash && active && confirmed) {
+                found = 1
+            }
+            in_slot = 1
+            found_hash = 0
+            active = 0
+            confirmed = 0
+            next
+        }
+        in_slot && /^[[:space:]]*flags:/ {
+            active = ($0 ~ /(^|[[:space:]])active([[:space:]]|$)/)
+            confirmed = ($0 ~ /(^|[[:space:]])confirmed([[:space:]]|$)/)
+        }
+        in_slot && /^[[:space:]]*hash:/ {
+            found_hash = ($2 == hash)
+        }
+        END {
+            if (in_slot && found_hash && active && confirmed) {
+                found = 1
+            }
+            exit(found ? 0 : 1)
+        }
+    '
+}
+
 echo "MCU: ${MCU_IP}:${MCU_PORT}"
 echo "Image: ${IMAGE}"
 echo
@@ -159,11 +188,15 @@ deadline=$((SECONDS + POLL_SECONDS))
 while (( SECONDS < deadline )); do
     if final_list="$(mcumgr image list 2>/dev/null)"; then
         printf '%s\n' "$final_list"
-        exit 0
+        if printf '%s\n' "$final_list" | is_hash_active_confirmed "$test_hash"; then
+            echo "Uploaded image is active and confirmed."
+            exit 0
+        fi
+        echo "MCU responded, waiting for uploaded image to become active confirmed..."
     fi
     sleep 2
 done
 
-echo "Warning: MCU did not respond to MCUmgr within ${POLL_SECONDS}s after reset." >&2
-echo "Check power, Ethernet link, and the direct-link network profile." >&2
+echo "Warning: uploaded image did not become active confirmed within ${POLL_SECONDS}s after reset." >&2
+echo "Check power, Ethernet link, MCUmgr image state, and serial logs." >&2
 exit 1


### PR DESCRIPTION
Updates the Ethernet OTA helpers so they do not exit on the first successful post-reset MCUmgr response. They now keep polling until the uploaded hash is reported as `active confirmed`.

Validation:
- `bash -n tools/k2-ota.sh`
- `shellcheck tools/k2-ota.sh`
- PowerShell parser check for `tools/k2-ota.ps1`
- live Ethernet OTA from `0.0.1` to `0.0.2`; helper observed pending and active-only states, then exited only after the uploaded hash became `active confirmed`