### PR TITLE
add reset command and imu retry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(app PRIVATE src/main.c
                            src/net/control_telemetry.c
                            src/net/log_backend_udp.c
                            src/net/setpoint_override.c
+                           src/net/system_control.c
                            src/net/ota_confirm.c
                            src/imu/vn100s.c
                            src/imu/axis_config.c

--- a/prj.conf
+++ b/prj.conf
@@ -17,10 +17,11 @@ CONFIG_LOG_RUNTIME_FILTERING=n
 # Per-module compile-time levels are set in each source file via
 # LOG_MODULE_REGISTER(name, LOG_LEVEL_xxx) — no Kconfig overrides needed.
 CONFIG_UART_CONSOLE=y
+CONFIG_REBOOT=y
 
 # ==================== SOCKET LIMITS ====================
-# 8 concurrent UDP sockets (command, telem, pid_config, axis_config,
-# sp_override, resource_monitor, log_udp, ctrl_telem) + 2 headroom
+# 9 concurrent UDP sockets (command, telem, pid_config, axis_config,
+# sp_override, system_control, resource_monitor, log_udp, ctrl_telem) + headroom
 CONFIG_ZVFS_OPEN_MAX=16
 CONFIG_NET_MAX_CONTEXTS=10
 

--- a/src/imu/vn100s.c
+++ b/src/imu/vn100s.c
@@ -24,6 +24,9 @@ static const struct spi_dt_spec vn_spi = SPI_DT_SPEC_GET(
 /* VN-100S SPI binary protocol commands */
 #define VN_CMD_READ  0x01
 
+#define VN_INIT_RETRY_MS 10000
+#define VN_STALE_REINIT_MS 10000
+
 /* Register IDs */
 #define VN_REG_MODEL       1    /* Model string (24 bytes ASCII) */
 #define VN_REG_YPR_RATE_AC 239  /* YPR + rates + linear accel body (9x float32 = 36 bytes) */
@@ -168,6 +171,7 @@ static bool vn_sane(float yaw, float pitch, float roll,
 static float last_yaw, last_pitch, last_roll;
 static float last_yr, last_pr, last_rr;
 static float last_ax, last_ay, last_az;
+static int64_t last_sample_time;
 
 void vn100s_get_ypr(float *yaw, float *pitch, float *roll)
 {
@@ -201,13 +205,22 @@ void vn100s_task(void *p1, void *p2, void *p3)
     LOG_DBG("VN-100S thread starting");
 
     struct vn100s_data dev;
-    int err = vn100s_init(&dev);
-    if (err) {
-        LOG_ERR("VN-100S init failed: %d", err);
-        return;
-    }
+    bool initialized = false;
+    int err = 0;
 
     while (1) {
+        if (!initialized) {
+            err = vn100s_init(&dev);
+            if (err) {
+                LOG_ERR("VN-100S init failed: %d; retrying in %d s",
+                        err, VN_INIT_RETRY_MS / 1000);
+                k_msleep(VN_INIT_RETRY_MS);
+                continue;
+            }
+            initialized = true;
+            last_sample_time = k_uptime_get();
+        }
+
         float yaw, pitch, roll, yr, pr, rr, ax, ay, az;
         err = vn100s_read_all(&yaw, &pitch, &roll, &yr, &pr, &rr, &ax, &ay, &az);
         if (!err) {
@@ -221,6 +234,7 @@ void vn100s_task(void *p1, void *p2, void *p3)
                 last_ax    = ax;
                 last_ay    = ay;
                 last_az    = az;
+                last_sample_time = k_uptime_get();
             } else {
                 LOG_WRN("VN-100S: corrupt sample "
                         "(y=%d p=%d r=%d)",
@@ -229,6 +243,13 @@ void vn100s_task(void *p1, void *p2, void *p3)
         } else {
             LOG_ERR("VN-100S read err %d", err);
         }
+
+        if ((k_uptime_get() - last_sample_time) > VN_STALE_REINIT_MS) {
+            LOG_WRN("VN-100S has no valid data for %d s; reinitializing",
+                    VN_STALE_REINIT_MS / 1000);
+            initialized = false;
+        }
+
         k_msleep(50);
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@
 #include "imu/axis_config.h"
 #include "net/control_telemetry.h"
 #include "net/setpoint_override.h"
+#include "net/system_control.h"
 #include "net/ota_confirm.h"
 
 /* Defined in net/log_backend_udp.c */
@@ -87,6 +88,9 @@ int main(void)
 
     // Start setpoint override listener
     setpoint_override_start();
+
+    // Start system control listener
+    system_control_start();
 
     // Confirm a trial MCUboot image only after the app and network come up
     ota_confirm_init();

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -17,6 +17,7 @@
 #define CONTROL_TELEM_PORT 5005
 #define LOG_UDP_PORT       5006
 #define SETPOINT_OVR_PORT  5007
+#define SYSTEM_CONTROL_PORT 5008
 
 extern bool network_ready;
 extern int udp_sock;

--- a/src/net/system_control.c
+++ b/src/net/system_control.c
@@ -1,0 +1,113 @@
+/*
+ * System Control — UDP listener for high-level MCU control commands.
+ *
+ * Listens on SYSTEM_CONTROL_PORT (5008) for reset packets:
+ *   | magic "RST1" (4B) | sequence (u32 big-endian) | crc32 (u32 big-endian) |
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/sys/reboot.h>
+#include <string.h>
+
+#include "net.h"
+#include "resource_monitor.h"
+#include "system_control.h"
+
+LOG_MODULE_REGISTER(system_control, LOG_LEVEL_INF);
+
+#define RESET_MAGIC "RST1"
+#define STACK_SIZE 2048
+
+typedef struct {
+    char magic[4];
+    uint32_t sequence;
+    uint32_t crc32;
+} __attribute__((packed)) reset_packet_t;
+
+K_THREAD_STACK_DEFINE(system_control_stack, STACK_SIZE);
+static struct k_thread system_control_thread_data;
+
+static void system_control_thread(void *a, void *b, void *c)
+{
+    ARG_UNUSED(a);
+    ARG_UNUSED(b);
+    ARG_UNUSED(c);
+
+    while (!network_ready) {
+        k_sleep(K_MSEC(100));
+    }
+
+    int sock = zsock_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock < 0) {
+        LOG_ERR("Failed to create system control socket: %d", sock);
+        return;
+    }
+
+    struct sockaddr_in bind_addr = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = INADDR_ANY,
+        .sin_port = htons(SYSTEM_CONTROL_PORT),
+    };
+
+    if (zsock_bind(sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
+        LOG_ERR("Failed to bind system control socket");
+        zsock_close(sock);
+        return;
+    }
+
+    LOG_INF("System control listener ready on port %d", SYSTEM_CONTROL_PORT);
+
+    reset_packet_t pkt;
+    struct sockaddr_in client;
+    socklen_t client_len = sizeof(client);
+
+    while (1) {
+        int ret = zsock_recvfrom(sock, &pkt, sizeof(pkt), 0,
+                                 (struct sockaddr *)&client, &client_len);
+
+        if (ret != sizeof(pkt)) {
+            if (ret < 0) {
+                LOG_ERR("System control recv error: %d", ret);
+                k_sleep(K_MSEC(100));
+            } else {
+                LOG_WRN("System control: wrong size %d (expected %d)",
+                        ret, (int)sizeof(pkt));
+            }
+            continue;
+        }
+
+        uint32_t calc_crc = crc32_calc(&pkt, sizeof(pkt) - sizeof(pkt.crc32));
+        uint32_t recv_crc = ntohl(pkt.crc32);
+        if (calc_crc != recv_crc) {
+            LOG_WRN("System control CRC mismatch");
+            resource_monitor_inc_udp_errors();
+            continue;
+        }
+
+        if (memcmp(pkt.magic, RESET_MAGIC, sizeof(pkt.magic)) != 0) {
+            LOG_WRN("System control: unknown command");
+            resource_monitor_inc_udp_errors();
+            continue;
+        }
+
+        resource_monitor_inc_udp_rx();
+        LOG_WRN("MCU reset requested by topside (seq #%u)", ntohl(pkt.sequence));
+        k_msleep(100);
+        sys_reboot(SYS_REBOOT_COLD);
+    }
+}
+
+void system_control_start(void)
+{
+    k_tid_t tid = k_thread_create(&system_control_thread_data,
+                                  system_control_stack,
+                                  K_THREAD_STACK_SIZEOF(system_control_stack),
+                                  system_control_thread,
+                                  NULL, NULL, NULL,
+                                  K_PRIO_COOP(7), 0, K_NO_WAIT);
+    if (tid) {
+        k_thread_name_set(tid, "system_control");
+    }
+}

--- a/src/net/system_control.h
+++ b/src/net/system_control.h
@@ -1,0 +1,4 @@
+#pragma once
+
+/* Start the system control UDP listener thread (port 5008). */
+void system_control_start(void);


### PR DESCRIPTION
## What changed

- Adds a CRC-checked UDP system control listener on port 5008 for topside reset commands.
- Performs a cold MCU reboot after a valid reset packet is received.
- Retries VN-100S initialization every 10 seconds when init fails, and reinitializes if valid IMU samples stop arriving for about 10 seconds.
- Enables Zephyr reboot support for the reset path.

## Why

This lets operators recover the MCU from the debug UI without power cycling, and keeps the rest of the firmware running while the IMU is unavailable or recovering.

## Paired PR

- Topside PR: https://github.com/UiASub/Topside/pull/37

## Validation

- `west build -d build` in the feature worktree for `nucleo_h755zi_q/stm32h755xx/m7`