### PR TITLE
update recommended Python version to 3.12 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Official Setup Guide: <https://docs.zephyrproject.org/4.2.0/develop/getting_star
 
 ### Recommended version
 
-- **Python**: 3.11
+- **Python**: 3.12
 
 ## Quick Installation
 


### PR DESCRIPTION
Zephyr official docs recommend Python 3.12, we should bump our recommended version to the same.