### PR TITLE
Add frame lock control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(app PRIVATE src/main.c
                            src/net/log_backend_udp.c
                            src/net/setpoint_override.c
                            src/net/system_control.c
+                           src/net/frame_control.c
                            src/net/ota_confirm.c
                            src/depth/ms5837.c
                            src/imu/vn100s.c

--- a/src/control.c
+++ b/src/control.c
@@ -1,6 +1,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <string.h>
+#include <math.h>
 #include "control.h"
 #include "pid/pid_controller.h"
 #include "pid/pid_config.h"
@@ -82,6 +83,11 @@ static uint8_t override_mask;           /* bitmask: bit 0=surge … bit 5=yaw */
 static float   override_setpoint[6];
 K_MUTEX_DEFINE(override_mutex);
 
+/* Reference-frame lock. When active, depth/heave PID output is interpreted as
+ * world-up and rotated into body-frame surge/sway/heave before thruster mixing. */
+static frame_lock_state_t frame_lock;
+K_MUTEX_DEFINE(frame_lock_mutex);
+
 /* ---------------------------------------------------------------------------
  * Helpers
  * --------------------------------------------------------------------------- */
@@ -119,6 +125,43 @@ static bool depth_sensor_read(float *depth_m)
     return true;
 }
 
+static void read_remapped_ypr(float *yaw, float *pitch, float *roll)
+{
+    float raw_yaw, raw_pitch, raw_roll;
+    vn100s_get_ypr(&raw_yaw, &raw_pitch, &raw_roll);
+    axis_config_remap_ypr(raw_yaw, raw_pitch, raw_roll, yaw, pitch, roll);
+}
+
+static void apply_locked_world_heave(float out[6], float heave_output,
+                                     float yaw_meas, float pitch_meas,
+                                     float roll_meas)
+{
+    ARG_UNUSED(yaw_meas);
+
+    frame_lock_state_t lock;
+    k_mutex_lock(&frame_lock_mutex, K_FOREVER);
+    lock = frame_lock;
+    k_mutex_unlock(&frame_lock_mutex);
+
+    if (!lock.active) {
+        return;
+    }
+
+    const float deg_to_rad = 0.017453293f;
+    float pitch = wrap_180(pitch_meas - lock.reference_pitch) * deg_to_rad;
+    float roll = wrap_180(roll_meas - lock.reference_roll) * deg_to_rad;
+    float sp = sinf(pitch);
+    float cp = cosf(pitch);
+    float sr = sinf(roll);
+    float cr = cosf(roll);
+
+    /* Match the existing control convention: positive pitch is nose-up, so a
+     * world-up correction includes positive surge when the ROV is pitched up. */
+    out[0] += heave_output * sp;
+    out[1] += heave_output * (-cp * sr);
+    out[2] = heave_output * cp * cr;
+}
+
 /* ---------------------------------------------------------------------------
  * Sync PID gains from the UDP-configurable store
  * --------------------------------------------------------------------------- */
@@ -142,14 +185,8 @@ static void stabilise(float out[6])
     float err_snap[6] = {0};
 
     /* ---- Read sensors ---- */
-    float raw_yaw, raw_pitch, raw_roll;
-    vn100s_get_ypr(&raw_yaw, &raw_pitch, &raw_roll);
-
-    /* Apply axis remapping (configured from topside) so PID sees the
-     * correct orientation even if the IMU is mounted non-standard. */
     float yaw_meas, pitch_meas, roll_meas;
-    axis_config_remap_ypr(raw_yaw, raw_pitch, raw_roll,
-                          &yaw_meas, &pitch_meas, &roll_meas);
+    read_remapped_ypr(&yaw_meas, &pitch_meas, &roll_meas);
 
     float raw_ax, raw_ay, raw_az;
     vn100s_get_accel(&raw_ax, &raw_ay, &raw_az);
@@ -184,6 +221,7 @@ static void stabilise(float out[6])
 
     float depth_meas;
     bool  depth_valid = depth_sensor_read(&depth_meas);
+    bool  transform_world_heave = false;
 
     /* ---- Grab pilot stick snapshot ---- */
     int8_t p_surge, p_sway, p_heave, p_roll, p_pitch, p_yaw;
@@ -354,6 +392,7 @@ static void stabilise(float out[6])
         depth_setpoint = -ovr_sp[PID_HEAVE];
         out[2] = pid_compute(&pid[PID_HEAVE], depth_setpoint, -depth_meas, CONTROL_DT);
         sp_snap[2] = -depth_setpoint;  err_snap[2] = sp_snap[2] - depth_meas;
+        transform_world_heave = true;
     } else if (pid_is_disabled(&pid[PID_HEAVE])) {
         out[2] = stick_normalize(p_heave);
         depth_setpoint = -depth_meas;
@@ -363,6 +402,11 @@ static void stabilise(float out[6])
         depth_setpoint += stick_normalize(p_heave) * MAX_DEPTH_RATE_MPS * CONTROL_DT;
         out[2] = pid_compute(&pid[PID_HEAVE], depth_setpoint, -depth_meas, CONTROL_DT);
         sp_snap[2] = -depth_setpoint;  err_snap[2] = sp_snap[2] - depth_meas;
+        transform_world_heave = true;
+    }
+
+    if (transform_world_heave) {
+        apply_locked_world_heave(out, out[2], yaw_meas, pitch_meas, roll_meas);
     }
 
     /* Publish telemetry snapshot */
@@ -533,6 +577,12 @@ void rov_control_init(void)
     for (int i = 0; i < 2; i++) est_speed[i] = 0.0f;
     depth_setpoint = 0.0f;
     depth_was_valid = false;
+    k_mutex_lock(&frame_lock_mutex, K_FOREVER);
+    frame_lock.active = false;
+    frame_lock.reference_yaw = 0.0f;
+    frame_lock.reference_pitch = 0.0f;
+    frame_lock.reference_roll = 0.0f;
+    k_mutex_unlock(&frame_lock_mutex);
     last_cmd_time = 0;
 
     LOG_INF("ROV control system initialized (50 Hz, PID stabilisation)");
@@ -575,6 +625,37 @@ void control_clear_override(void)
     override_mask = 0;
     k_mutex_unlock(&override_mutex);
     LOG_INF("Setpoint override cleared");
+}
+
+void control_frame_lock_enable(void)
+{
+    float yaw, pitch, roll;
+    read_remapped_ypr(&yaw, &pitch, &roll);
+
+    k_mutex_lock(&frame_lock_mutex, K_FOREVER);
+    frame_lock.active = true;
+    frame_lock.reference_yaw = yaw;
+    frame_lock.reference_pitch = pitch;
+    frame_lock.reference_roll = roll;
+    k_mutex_unlock(&frame_lock_mutex);
+
+    LOG_INF("Frame lock enabled: yaw=%d pitch=%d roll=%d",
+            (int)yaw, (int)pitch, (int)roll);
+}
+
+void control_frame_lock_disable(void)
+{
+    k_mutex_lock(&frame_lock_mutex, K_FOREVER);
+    frame_lock.active = false;
+    k_mutex_unlock(&frame_lock_mutex);
+    LOG_INF("Frame lock disabled");
+}
+
+void control_get_frame_lock(frame_lock_state_t *out)
+{
+    k_mutex_lock(&frame_lock_mutex, K_FOREVER);
+    *out = frame_lock;
+    k_mutex_unlock(&frame_lock_mutex);
 }
 
 void rov_send_command(uint32_t sequence, uint64_t payload)

--- a/src/control.h
+++ b/src/control.h
@@ -2,6 +2,7 @@
 
 #include <zephyr/kernel.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /* Message structure for communication between threads */
 typedef struct {
@@ -24,6 +25,13 @@ typedef struct {
     float error[6];     /* setpoint - measurement (0 when passthrough) */
 } control_telemetry_t;
 
+typedef struct {
+    bool active;
+    float reference_yaw;
+    float reference_pitch;
+    float reference_roll;
+} frame_lock_state_t;
+
 /* Public functions */
 void rov_control_init(void);
 void rov_control_start(void);
@@ -40,3 +48,12 @@ void control_set_override(uint8_t axis_mask, const float setpoints[6]);
 
 /* Clear all overrides — return to normal stick control */
 void control_clear_override(void);
+
+/* Capture the current attitude as the reference frame for world-up heave. */
+void control_frame_lock_enable(void);
+
+/* Disable reference-frame compensation. */
+void control_frame_lock_disable(void);
+
+/* Copy the latest frame-lock state. */
+void control_get_frame_lock(frame_lock_state_t *out);

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@
 #include "net/control_telemetry.h"
 #include "net/setpoint_override.h"
 #include "net/system_control.h"
+#include "net/frame_control.h"
 #include "net/ota_confirm.h"
 
 /* Defined in net/log_backend_udp.c */
@@ -94,6 +95,9 @@ int main(void)
 
     // Start system control listener
     system_control_start();
+
+    // Start frame control listener
+    frame_control_start();
 
     // Confirm a trial MCUboot image only after the app and network come up
     ota_confirm_init();

--- a/src/net/frame_control.c
+++ b/src/net/frame_control.c
@@ -1,0 +1,135 @@
+/*
+ * Frame Control — UDP listener for reference-frame lock commands.
+ *
+ * Listens on FRAME_CONTROL_PORT (5009) for packets:
+ *   | magic "FRM1" (4B) | command (1B) | reserved (3B)
+ *   | sequence (u32 big-endian) | crc32 (u32 big-endian) |
+ *
+ * Commands:
+ *   0x01 = lock current attitude as the world-up reference
+ *   0x02 = unlock reference-frame compensation
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/socket.h>
+#include <string.h>
+
+#include "../control.h"
+#include "frame_control.h"
+#include "net.h"
+#include "resource_monitor.h"
+
+LOG_MODULE_REGISTER(frame_control, LOG_LEVEL_INF);
+
+#define FRAME_MAGIC "FRM1"
+#define FRAME_CMD_LOCK   0x01
+#define FRAME_CMD_UNLOCK 0x02
+#define STACK_SIZE 2048
+
+typedef struct {
+    char magic[4];
+    uint8_t command;
+    uint8_t reserved[3];
+    uint32_t sequence;
+    uint32_t crc32;
+} __attribute__((packed)) frame_packet_t;
+
+K_THREAD_STACK_DEFINE(frame_control_stack, STACK_SIZE);
+static struct k_thread frame_control_thread_data;
+
+static void frame_control_thread(void *a, void *b, void *c)
+{
+    ARG_UNUSED(a);
+    ARG_UNUSED(b);
+    ARG_UNUSED(c);
+
+    while (!network_ready) {
+        k_sleep(K_MSEC(100));
+    }
+
+    int sock = zsock_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock < 0) {
+        LOG_ERR("Failed to create frame control socket: %d", sock);
+        return;
+    }
+
+    struct sockaddr_in bind_addr = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = INADDR_ANY,
+        .sin_port = htons(FRAME_CONTROL_PORT),
+    };
+
+    if (zsock_bind(sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
+        LOG_ERR("Failed to bind frame control socket");
+        zsock_close(sock);
+        return;
+    }
+
+    LOG_INF("Frame control listener ready on port %d", FRAME_CONTROL_PORT);
+
+    frame_packet_t pkt;
+    struct sockaddr_in client;
+    socklen_t client_len = sizeof(client);
+
+    while (1) {
+        int ret = zsock_recvfrom(sock, &pkt, sizeof(pkt), 0,
+                                 (struct sockaddr *)&client, &client_len);
+
+        if (ret != sizeof(pkt)) {
+            if (ret < 0) {
+                LOG_ERR("Frame control recv error: %d", ret);
+                k_sleep(K_MSEC(100));
+            } else {
+                LOG_WRN("Frame control: wrong size %d (expected %d)",
+                        ret, (int)sizeof(pkt));
+                resource_monitor_inc_udp_errors();
+            }
+            continue;
+        }
+
+        uint32_t calc_crc = crc32_calc(&pkt, sizeof(pkt) - sizeof(pkt.crc32));
+        uint32_t recv_crc = ntohl(pkt.crc32);
+        if (calc_crc != recv_crc) {
+            LOG_WRN("Frame control CRC mismatch");
+            resource_monitor_inc_udp_errors();
+            continue;
+        }
+
+        if (memcmp(pkt.magic, FRAME_MAGIC, sizeof(pkt.magic)) != 0) {
+            LOG_WRN("Frame control: unknown magic");
+            resource_monitor_inc_udp_errors();
+            continue;
+        }
+
+        switch (pkt.command) {
+        case FRAME_CMD_LOCK:
+            control_frame_lock_enable();
+            resource_monitor_inc_udp_rx();
+            LOG_INF("Frame lock requested by topside (seq #%u)", ntohl(pkt.sequence));
+            break;
+        case FRAME_CMD_UNLOCK:
+            control_frame_lock_disable();
+            resource_monitor_inc_udp_rx();
+            LOG_INF("Frame unlock requested by topside (seq #%u)", ntohl(pkt.sequence));
+            break;
+        default:
+            LOG_WRN("Frame control: unknown command 0x%02X", pkt.command);
+            resource_monitor_inc_udp_errors();
+            break;
+        }
+    }
+}
+
+void frame_control_start(void)
+{
+    k_tid_t tid = k_thread_create(&frame_control_thread_data,
+                                  frame_control_stack,
+                                  K_THREAD_STACK_SIZEOF(frame_control_stack),
+                                  frame_control_thread,
+                                  NULL, NULL, NULL,
+                                  K_PRIO_COOP(7), 0, K_NO_WAIT);
+    if (tid) {
+        k_thread_name_set(tid, "frame_control");
+    }
+}

--- a/src/net/frame_control.h
+++ b/src/net/frame_control.h
@@ -1,0 +1,4 @@
+#pragma once
+
+/* Start the frame-control UDP listener thread (port 5009). */
+void frame_control_start(void);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -335,6 +335,7 @@ void sensor_sender_thread(void *arg1, void *arg2, void *arg3)
     float ax, ay, az;
     ms5837_sample_t depth;
     control_telemetry_t ctrl_telem;
+    frame_lock_state_t frame_lock;
 
     while (!network_ready) {
         k_sleep(K_MSEC(100));
@@ -369,6 +370,7 @@ void sensor_sender_thread(void *arg1, void *arg2, void *arg3)
         vn100s_get_accel(&ax, &ay, &az);
         ms5837_get_sample(&depth);
         control_get_telemetry(&ctrl_telem);
+        control_get_frame_lock(&frame_lock);
 
         int len = snprintf(buffer, sizeof(buffer),
             "{\"imu\":{\"yaw\":%.2f,\"pitch\":%.2f,\"roll\":%.2f,"
@@ -378,7 +380,8 @@ void sensor_sender_thread(void *arg1, void *arg2, void *arg3)
             "\"pressure_mbar\":%.1f,\"temperature_c\":%.2f,"
             "\"valid\":%s,\"age_ms\":%lld,"
             "\"addr\":%u,\"last_error\":%d,"
-            "\"init_attempts\":%u,\"read_errors\":%u}}",
+            "\"init_attempts\":%u,\"read_errors\":%u},"
+            "\"frame\":{\"locked\":%s,\"yaw\":%.2f,\"pitch\":%.2f,\"roll\":%.2f}}",
             (double)yaw, (double)pitch, (double)roll,
             (double)yr, (double)pr, (double)rr,
             (double)ax, (double)ay, (double)az,
@@ -386,7 +389,11 @@ void sensor_sender_thread(void *arg1, void *arg2, void *arg3)
             (double)depth.pressure_mbar, (double)depth.temperature_c,
             depth.valid ? "true" : "false", (long long)depth.age_ms,
             depth.addr, depth.last_error,
-            depth.init_attempts, depth.read_errors);
+            depth.init_attempts, depth.read_errors,
+            frame_lock.active ? "true" : "false",
+            (double)frame_lock.reference_yaw,
+            (double)frame_lock.reference_pitch,
+            (double)frame_lock.reference_roll);
 
         if (len > 0 && len < sizeof(buffer)) {
             ret = zsock_sendto(sock, buffer, len, 0,

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -18,6 +18,7 @@
 #define LOG_UDP_PORT       5006
 #define SETPOINT_OVR_PORT  5007
 #define SYSTEM_CONTROL_PORT 5008
+#define FRAME_CONTROL_PORT  5009
 
 extern bool network_ready;
 extern int udp_sock;


### PR DESCRIPTION
Adds a frame-control UDP command path for locking and unlocking a reference frame during PID tuning.

The firmware stores the current attitude as the frame reference, reports the lock state in sensor telemetry, and rotates active heave PID output into body-frame surge/sway/heave so depth hold remains world-up while the ROV pitches or rolls.

Validation:
- git diff --check
- ./build.sh --h7 reaches the new frame-control/control/net objects, then stops on the existing src/vesc/vesc_uart_zephyr.c:38 uart_irq_update(dev) void-expression build blocker.