### PR TITLE
fix uart irq update

### DIFF
--- a/src/vesc/vesc_uart_zephyr.c
+++ b/src/vesc/vesc_uart_zephyr.c
@@ -35,9 +35,7 @@ static void uart_isr_callback(const struct device *dev, void *user_data)
 {
     ARG_UNUSED(user_data);
 
-    if (!uart_irq_update(dev)) {
-        return;
-    }
+    uart_irq_update(dev);
 
     if (uart_irq_tx_ready(dev)) {
         uint16_t head = tx_head;


### PR DESCRIPTION
Fixes the VESC UART ISR so uart_irq_update() is always called before checking TX readiness, without returning early when the driver reports no pending update.

This is split out from the PID/frame-lock work so the stacked draft branches can rebase onto main after this lands.

Validated with:

```bash
west build --sysbuild -p -b nucleo_h755zi_q/stm32h755xx/m7 -d build-h755-ota-mainfix . -- -DEXTRA_CONF_FILE=ota.conf
```