### PR TITLE
fix windows ota build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,12 +1,23 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$workspace = Join-Path -Path $HOME -ChildPath 'zephyrproject'
+$projectPath = $PSScriptRoot
+if (-not $projectPath) {
+    $projectPath = (Get-Location).Path
+}
+
+$workspace = Split-Path -Parent $projectPath
 $venvActivate = Join-Path -Path $workspace -ChildPath '.venv\Scripts\Activate.ps1'
-$projectPath = Join-Path -Path $workspace -ChildPath 'K2-Zephyr'
 $board = 'nucleo_h755zi_q/stm32h755xx/m7'
 $boardLabel = 'H7 (nucleo_h755zi_q/stm32h755xx/m7)'
 $otaBuild = $false
+
+function Invoke-West {
+    & west @args
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
 
 foreach ($arg in $args) {
     switch ($arg.ToLowerInvariant()) {
@@ -37,7 +48,7 @@ foreach ($arg in $args) {
 if (Test-Path $venvActivate) {
     & $venvActivate
 } elseif (-not (Get-Command west -ErrorAction SilentlyContinue)) {
-    Write-Host "west not found. Install west or create $workspace\.venv."
+    Write-Host "west not found. Install west or create a Zephyr virtual environment at $workspace\.venv."
     exit 1
 }
 
@@ -45,10 +56,10 @@ Set-Location $projectPath
 if ($otaBuild) {
     $buildDir = if ($board -eq 'nucleo_f767zi') { 'build-f767-ota' } else { 'build-h755-ota' }
     Write-Host "Building K2-Zephyr OTA image for $boardLabel..."
-    west build --sysbuild -p -b $board -d $buildDir . -- "-DEXTRA_CONF_FILE=ota.conf"
+    Invoke-West build --sysbuild -p -b $board -d $buildDir . -- "-DEXTRA_CONF_FILE=ota.conf"
     Write-Host "OTA build complete for $boardLabel! Flash with: west flash -d $buildDir"
 } else {
     Write-Host "Building K2-Zephyr for $boardLabel..."
-    west build -p -b $board
+    Invoke-West build -p -b $board
     Write-Host "Build complete for $boardLabel! Flash with: west flash"
 }

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ set -e  # Exit on error
 board="nucleo_h755zi_q/stm32h755xx/m7"
 board_label="H7 (nucleo_h755zi_q/stm32h755xx/m7)"
 ota_build=0
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace="$(dirname "$script_dir")"
 
 usage() {
     echo "Usage: ./build.sh [--h7|--H7|--f7|--F7] [--ota|--OTA]"
@@ -42,17 +44,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "Setting up Zephyr environment..."
-cd ~/zephyrproject || exit 1
+cd "$workspace" || exit 1
 
 if [[ -f .venv/bin/activate ]]; then
     # shellcheck source=/dev/null
     source .venv/bin/activate
 elif ! command -v west >/dev/null 2>&1; then
-    echo "west not found. Install west or create ~/zephyrproject/.venv." >&2
+    echo "west not found. Install west or create a Zephyr virtual environment at ${workspace}/.venv." >&2
     exit 1
 fi
 
-cd ~/zephyrproject/K2-Zephyr || exit 1
+cd "$script_dir" || exit 1
 if [[ "$ota_build" -eq 1 ]]; then
     if [[ "$board" == "nucleo_f767zi" ]]; then
         build_dir="build-f767-ota"


### PR DESCRIPTION
Fixes the Windows OTA build wrapper so failed west builds stop the PowerShell script instead of printing a false success message.

Also makes both build wrappers resolve the project from the script location rather than assuming the checkout is exactly at ~/zephyrproject/K2-Zephyr.

Validated with:
- pwsh -NoProfile -File ./build.ps1 --help
- ./build.sh --help
- bash -n build.sh
- fake failing west exits build.ps1 with status 1
- pwsh -NoProfile -File ./build.ps1 --H7 --OTA