### PR TITLE
Make OTA the default K2 build path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         board:
           - nucleo_h755zi_q/stm32h755xx/m7
-          - nucleo_f767zi
 
     outputs:
       tag: ${{ steps.version.outputs.tag }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ project(k2_zephyr_app)
 set(BOARD_FLASH_RUNNER openocd)
 set(BOARD_DEBUG_RUNNER openocd)
 
+message(STATUS "K2 flashing: use Ethernet OTA helpers for normal updates; use west flash only for first-time USB provisioning or debug recovery.")
+
 # Tell Zephyr to compile our main source file into the application
 # 'app' is Zephyr's standard target name for the main application binary
 target_sources(app PRIVATE src/main.c

--- a/ETHERNET_OTA.md
+++ b/ETHERNET_OTA.md
@@ -139,8 +139,8 @@ slot for test boot, resets the MCU, and then polls until MCUmgr responds again:
 ```
 
 By default, the helper finds the signed image at
-`build-h755-ota/<app>/zephyr/zephyr.signed.bin`. To upload a different signed
-image:
+`build-h755-ota/K2-Zephyr/zephyr/zephyr.signed.bin`. To upload a different
+signed image:
 
 ```bash
 ./tools/k2-ota.sh path/to/zephyr.signed.bin
@@ -155,7 +155,7 @@ On Windows:
 Manual fallback:
 
 ```bash
-mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' image upload build-h755-ota/<app>/zephyr/zephyr.signed.bin
+mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' image upload build-h755-ota/K2-Zephyr/zephyr/zephyr.signed.bin
 mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' image list
 mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' image test <slot-1-hash>
 mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' reset

--- a/ETHERNET_OTA.md
+++ b/ETHERNET_OTA.md
@@ -95,9 +95,27 @@ Test-Connection 10.77.0.2 -Count 2
 Replace `"Ethernet"` with the adapter connected to the MCU. Do not configure a
 default gateway for this direct-link interface.
 
-## Verify the Flashed Image
+## Provision and Verify the Board
 
-After flashing the OTA build once over USB, verify the board in this order:
+Build scripts create the H7 OTA image by default:
+
+```bash
+./build.sh
+```
+
+On Windows:
+
+```powershell
+.\build.ps1
+```
+
+Use USB flashing only for first-time provisioning or recovery:
+
+```bash
+west flash -d build-h755-ota
+```
+
+After provisioning the OTA build once over USB, verify the board in this order:
 
 1. Check the serial log for startup, static IP configuration, UDP server
    startup, and MCUboot image state.
@@ -120,8 +138,9 @@ slot for test boot, resets the MCU, and then polls until MCUmgr responds again:
 ./tools/k2-ota.sh
 ```
 
-The default image is `build-h755-ota/K2-Zephyr/zephyr/zephyr.signed.bin`. To
-upload a different signed image:
+By default, the helper finds the signed image at
+`build-h755-ota/<app>/zephyr/zephyr.signed.bin`. To upload a different signed
+image:
 
 ```bash
 ./tools/k2-ota.sh path/to/zephyr.signed.bin
@@ -136,7 +155,7 @@ On Windows:
 Manual fallback:
 
 ```bash
-mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' image upload build-h755-ota/K2-Zephyr/zephyr/zephyr.signed.bin
+mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' image upload build-h755-ota/<app>/zephyr/zephyr.signed.bin
 mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' image list
 mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' image test <slot-1-hash>
 mcumgr --conntype udp '--connstring=[10.77.0.2]:1337' reset

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ On Windows:
 This creates a sysbuild output with:
 
 - MCUboot in `build-h755-ota/mcuboot`
-- The signed application image in `build-h755-ota/<app>/zephyr/zephyr.signed.bin`
+- The signed application image in `build-h755-ota/K2-Zephyr/zephyr/zephyr.signed.bin`
 
 Flash the OTA build over USB only for first-time provisioning or recovery:
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ use `./install_zephyr.sh -h` to see help
 
 ## Building
 
-Default target is H7 (`nucleo_h755zi_q/stm32h755xx/m7`).
+The supported target is H7 (`nucleo_h755zi_q/stm32h755xx/m7`). The build
+scripts default to an MCUboot-enabled OTA build.
 
 ```bash
 ./build.sh
 ./build.sh --h7
-./build.sh --f7
 ./build.sh --ota
+./build.sh --no-ota
 ```
 
 On Windows:
@@ -57,46 +58,49 @@ On Windows:
 ```powershell
 .\build.ps1
 .\build.ps1 --H7
-.\build.ps1 --F7
 .\build.ps1 --OTA
+.\build.ps1 --NO-OTA
 ```
+
+Use `--no-ota` only when you intentionally need a plain non-MCUboot development
+image. F7 Nucleo support is sunset and is no longer documented or built by the
+project tooling.
 
 ## Ethernet OTA
 
-The repository now includes an MCUboot-based Ethernet OTA path using dual image
-slots and MCUmgr over UDP.
+The normal K2 firmware update path is MCUboot-based Ethernet OTA using dual
+image slots and MCUmgr over UDP.
 
 Build an OTA image with:
 
 ```bash
-./build.sh --h7 --ota
-./build.sh --f7 --ota
+./build.sh
 ```
 
 On Windows:
 
 ```powershell
-.\build.ps1 --H7 --OTA
-.\build.ps1 --F7 --OTA
+.\build.ps1
 ```
 
-For the H7 target, this creates a sysbuild output with:
+This creates a sysbuild output with:
 
 - MCUboot in `build-h755-ota/mcuboot`
-- The signed application image in `build-h755-ota/K2-Zephyr/zephyr/zephyr.signed.bin`
+- The signed application image in `build-h755-ota/<app>/zephyr/zephyr.signed.bin`
 
-Flash the OTA build once with:
+Flash the OTA build over USB only for first-time provisioning or recovery:
 
 ```bash
 west flash -d build-h755-ota
 ```
 
-After that, upload `zephyr.signed.bin` with an MCUmgr-compatible UDP client to
-the device on port `1337`, mark the image for test boot, and reset the device.
+After the board has been provisioned, upload `zephyr.signed.bin` with an
+MCUmgr-compatible UDP client to the device on port `1337`, mark the image for
+test boot, and reset the device.
 The application confirms the new image automatically after it finishes startup
 and the network interface is up. If the new image fails to boot or is rebooted
 before confirmation, MCUboot reverts to the previous image on the next reset.
-The field helper wraps the upload/test/reset flow:
+The helper wraps the normal upload/test/reset flow:
 
 ```bash
 ./tools/k2-ota.sh

--- a/build.ps1
+++ b/build.ps1
@@ -1,16 +1,26 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$projectPath = $PSScriptRoot
-if (-not $projectPath) {
-    $projectPath = (Get-Location).Path
-}
-
+$projectPath = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
 $workspace = Split-Path -Parent $projectPath
-$venvActivate = Join-Path -Path $workspace -ChildPath '.venv\Scripts\Activate.ps1'
+$venvActivateWindows = Join-Path -Path $workspace -ChildPath '.venv\Scripts\Activate.ps1'
+$venvActivateUnix = Join-Path -Path $workspace -ChildPath '.venv/bin/Activate.ps1'
 $board = 'nucleo_h755zi_q/stm32h755xx/m7'
 $boardLabel = 'H7 (nucleo_h755zi_q/stm32h755xx/m7)'
-$otaBuild = $false
+$otaBuild = $true
+
+function Show-Usage {
+    Write-Host 'Usage: .\build.ps1 [--h7|--H7] [--ota|--OTA] [--no-ota|--NO-OTA]'
+    Write-Host 'Defaults to the H7 OTA build. Use --no-ota only for a plain non-MCUboot development build.'
+}
+
+function Show-FlashGuidance {
+    Write-Host ''
+    Write-Host 'K2 flashing:'
+    Write-Host '  Ignore Zephyr''s generic "west flash" hint unless you are doing first-time USB'
+    Write-Host '  provisioning or debug recovery.'
+    Write-Host '  Normal updates should use: .\tools\k2-ota.ps1'
+}
 
 function Invoke-West {
     & west @args
@@ -22,31 +32,33 @@ function Invoke-West {
 foreach ($arg in $args) {
     switch ($arg.ToLowerInvariant()) {
         '--h7' {
-            $board = 'nucleo_h755zi_q/stm32h755xx/m7'
-            $boardLabel = 'H7 (nucleo_h755zi_q/stm32h755xx/m7)'
         }
         '--f7' {
-            $board = 'nucleo_f767zi'
-            $boardLabel = 'F7 (nucleo_f767zi)'
+            Write-Host "F7 support has been sunset. Use the H7 target: $board"
+            exit 1
         }
         '--ota' {
             $otaBuild = $true
         }
+        '--no-ota' {
+            $otaBuild = $false
+        }
         '--help' {
-            Write-Host 'Usage: .\build.ps1 [--h7|--H7|--f7|--F7] [--ota|--OTA]'
-            Write-Host 'Defaults to H7 if no board flag is provided. Use --ota for MCUboot + Ethernet OTA builds.'
+            Show-Usage
             exit 0
         }
         default {
             Write-Host "Unknown option: $arg"
-            Write-Host 'Usage: .\build.ps1 [--h7|--H7|--f7|--F7] [--ota|--OTA]'
+            Show-Usage
             exit 1
         }
     }
 }
 
-if (Test-Path $venvActivate) {
-    & $venvActivate
+if (Test-Path $venvActivateWindows) {
+    & $venvActivateWindows
+} elseif (Test-Path $venvActivateUnix) {
+    & $venvActivateUnix
 } elseif (-not (Get-Command west -ErrorAction SilentlyContinue)) {
     Write-Host "west not found. Install west or create a Zephyr virtual environment at $workspace\.venv."
     exit 1
@@ -54,12 +66,16 @@ if (Test-Path $venvActivate) {
 
 Set-Location $projectPath
 if ($otaBuild) {
-    $buildDir = if ($board -eq 'nucleo_f767zi') { 'build-f767-ota' } else { 'build-h755-ota' }
+    $buildDir = 'build-h755-ota'
     Write-Host "Building K2-Zephyr OTA image for $boardLabel..."
-    Invoke-West build --sysbuild -p -b $board -d $buildDir . -- "-DEXTRA_CONF_FILE=ota.conf"
-    Write-Host "OTA build complete for $boardLabel! Flash with: west flash -d $buildDir"
+    Invoke-West build --sysbuild -p -b $board -d $buildDir $projectPath -- "-DEXTRA_CONF_FILE=ota.conf"
+    Write-Host "OTA build complete for $boardLabel."
+    Write-Host "Signed image: $buildDir\*\zephyr\zephyr.signed.bin"
+    Show-FlashGuidance
 } else {
-    Write-Host "Building K2-Zephyr for $boardLabel..."
-    Invoke-West build -p -b $board
-    Write-Host "Build complete for $boardLabel! Flash with: west flash"
+    $buildDir = 'build-h755'
+    Write-Host "Building K2-Zephyr non-OTA image for $boardLabel..."
+    Invoke-West build -p -b $board -d $buildDir $projectPath
+    Write-Host "Non-OTA build complete for $boardLabel."
+    Write-Host "Use west flash -d $buildDir only when you intentionally need USB flashing."
 }

--- a/build.sh
+++ b/build.sh
@@ -1,36 +1,47 @@
 #!/usr/bin/env bash
 
 # Zephyr Build Script
-# This script sets up the environment and builds the K2-Zephyr project
+# This script sets up the environment and builds the K2-Zephyr project.
 
-set -e  # Exit on error
+set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workspace_dir="$(dirname "$script_dir")"
 board="nucleo_h755zi_q/stm32h755xx/m7"
 board_label="H7 (nucleo_h755zi_q/stm32h755xx/m7)"
-ota_build=0
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-workspace="$(dirname "$script_dir")"
+ota_build=1
 
 usage() {
-    echo "Usage: ./build.sh [--h7|--H7|--f7|--F7] [--ota|--OTA]"
-    echo "Defaults to H7 if no board flag is provided."
-    echo "Use --ota to build the MCUboot + Ethernet OTA image."
+    echo "Usage: ./build.sh [--h7|--H7] [--ota|--OTA] [--no-ota|--NO-OTA]"
+    echo "Defaults to the H7 OTA build."
+    echo "Use --no-ota only for a plain non-MCUboot development build."
+}
+
+print_flash_guidance() {
+    cat <<EOF
+
+K2 flashing:
+  Ignore Zephyr's generic "west flash" hint unless you are doing first-time USB
+  provisioning or debug recovery.
+  Normal updates should use: ./tools/k2-ota.sh
+EOF
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --h7|--H7)
-            board="nucleo_h755zi_q/stm32h755xx/m7"
-            board_label="H7 (nucleo_h755zi_q/stm32h755xx/m7)"
-            ;;
-        --f7|--F7)
-            board="nucleo_f767zi"
-            board_label="F7 (nucleo_f767zi)"
             ;;
         --ota|--OTA)
             ota_build=1
             ;;
-        --help)
+        --no-ota|--NO-OTA)
+            ota_build=0
+            ;;
+        --f7|--F7)
+            echo "F7 support has been sunset. Use the H7 target: ${board}" >&2
+            exit 1
+            ;;
+        --help|-h)
             usage
             exit 0
             ;;
@@ -44,28 +55,27 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "Setting up Zephyr environment..."
-cd "$workspace" || exit 1
 
-if [[ -f .venv/bin/activate ]]; then
+if [[ -f "${workspace_dir}/.venv/bin/activate" ]]; then
     # shellcheck source=/dev/null
-    source .venv/bin/activate
+    source "${workspace_dir}/.venv/bin/activate"
 elif ! command -v west >/dev/null 2>&1; then
-    echo "west not found. Install west or create a Zephyr virtual environment at ${workspace}/.venv." >&2
+    echo "west not found. Install west or create a Zephyr virtual environment at ${workspace_dir}/.venv." >&2
     exit 1
 fi
 
 cd "$script_dir" || exit 1
 if [[ "$ota_build" -eq 1 ]]; then
-    if [[ "$board" == "nucleo_f767zi" ]]; then
-        build_dir="build-f767-ota"
-    else
-        build_dir="build-h755-ota"
-    fi
+    build_dir="build-h755-ota"
     echo "Building K2-Zephyr OTA image for ${board_label}..."
-    west build --sysbuild -p -b "$board" -d "$build_dir" . -- "-DEXTRA_CONF_FILE=ota.conf"
-    echo "OTA build complete for ${board_label}! Flash with: west flash -d ${build_dir}"
+    west build --sysbuild -p -b "$board" -d "$build_dir" "$script_dir" -- "-DEXTRA_CONF_FILE=ota.conf"
+    echo "OTA build complete for ${board_label}."
+    echo "Signed image: ${build_dir}/*/zephyr/zephyr.signed.bin"
+    print_flash_guidance
 else
-    echo "Building K2-Zephyr project for ${board_label}..."
-    west build -p -b "$board"
-    echo "Build complete for ${board_label}! Flash with: west flash"
+    build_dir="build-h755"
+    echo "Building K2-Zephyr non-OTA image for ${board_label}..."
+    west build -p -b "$board" -d "$build_dir" "$script_dir"
+    echo "Non-OTA build complete for ${board_label}."
+    echo "Use west flash -d ${build_dir} only when you intentionally need USB flashing."
 fi

--- a/prj.conf
+++ b/prj.conf
@@ -45,7 +45,7 @@ CONFIG_NET_UDP=y
 CONFIG_NET_SOCKETS=y
 # Disable POSIX socket names, we use zsock_* explicitly
 # (No assignment here; symbol may not exist in this Zephyr version)
-# Enable Ethernet driver for STM32 (both F767ZI and H755ZI-Q have built-in Ethernet MAC)
+# Enable Ethernet driver for the STM32H755 Ethernet MAC
 CONFIG_ETH_STM32_HAL=y
 CONFIG_NET_L2_ETHERNET=y
 # Enable network buffer management

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@
  * 3. Logging system for debug output
  * 4. Networking (UDP server)
  * 
- * Target Hardware: ST NUCLEO-F767ZI or NUCLEO-H755ZI-Q development board
+ * Target Hardware: ST NUCLEO-H755ZI-Q development board
  * - UART console for debug messages (115200 baud via ST-LINK USB)
  */
 

--- a/tools/k2-ota.ps1
+++ b/tools/k2-ota.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$Image = "build-h755-ota/K2-Zephyr/zephyr/zephyr.signed.bin",
+    [string]$Image = $env:IMAGE,
     [string]$McuIp = "10.77.0.2",
     [int]$McuPort = 1337,
     [double]$Timeout = 10,
@@ -9,6 +9,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+$ProjectDir = Split-Path -Parent $ScriptDir
 
 function Find-Mcumgr {
     if ($env:MCUMGR) {
@@ -36,6 +38,27 @@ mcumgr not found. Install it with:
   go install github.com/apache/mynewt-mcumgr-cli/mcumgr@latest
 Then make sure %USERPROFILE%\go\bin is on PATH.
 "@
+}
+
+function Find-DefaultImage {
+    $matches = @(Get-ChildItem -Path (Join-Path $ProjectDir "build-h755-ota") `
+        -Recurse `
+        -Filter "zephyr.signed.bin" `
+        -File `
+        -ErrorAction SilentlyContinue | Where-Object {
+            $_.FullName -match "[\\/]zephyr[\\/]zephyr\.signed\.bin$"
+        })
+
+    if ($matches.Count -eq 1) {
+        return $matches[0].FullName
+    }
+
+    if ($matches.Count -gt 1) {
+        $paths = ($matches | ForEach-Object { "  $($_.FullName)" }) -join [Environment]::NewLine
+        throw "Multiple signed images found under build-h755-ota:$([Environment]::NewLine)$paths$([Environment]::NewLine)Pass the image path explicitly."
+    }
+
+    throw "Image not found under $ProjectDir\build-h755-ota\*\zephyr\zephyr.signed.bin. Build one first, for example: .\build.ps1"
 }
 
 function Invoke-Mcumgr {
@@ -109,9 +132,12 @@ function Test-HashActiveConfirmed {
 }
 
 $script:McumgrBin = Find-Mcumgr
+if (-not $Image) {
+    $Image = Find-DefaultImage
+}
 
 if (-not (Test-Path $Image)) {
-    throw "Image not found: $Image. Build one first, for example: ./build.sh --h7 --ota"
+    throw "Image not found: $Image. Build one first, for example: .\build.ps1"
 }
 
 Write-Host "MCU: ${McuIp}:${McuPort}"

--- a/tools/k2-ota.sh
+++ b/tools/k2-ota.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 MCU_IP="${MCU_IP:-10.77.0.2}"
 MCU_PORT="${MCU_PORT:-1337}"
-IMAGE="${IMAGE:-build-h755-ota/K2-Zephyr/zephyr/zephyr.signed.bin}"
+IMAGE="${IMAGE:-}"
 TIMEOUT="${TIMEOUT:-10}"
 TRIES="${TRIES:-2}"
 POLL_SECONDS="${POLL_SECONDS:-30}"
@@ -91,11 +93,37 @@ find_mcumgr() {
     exit 1
 }
 
+find_default_image() {
+    local matches=()
+    shopt -s nullglob
+    matches=("${PROJECT_DIR}"/build-h755-ota/*/zephyr/zephyr.signed.bin)
+    shopt -u nullglob
+
+    if ((${#matches[@]} == 1)); then
+        echo "${matches[0]}"
+        return
+    fi
+
+    if ((${#matches[@]} > 1)); then
+        echo "Multiple signed images found under build-h755-ota:" >&2
+        printf '  %s\n' "${matches[@]}" >&2
+        echo "Pass the image path explicitly." >&2
+        exit 1
+    fi
+
+    echo "Image not found under ${PROJECT_DIR}/build-h755-ota/*/zephyr/zephyr.signed.bin" >&2
+    echo "Build one first, for example: ./build.sh" >&2
+    exit 1
+}
+
 MCUMGR_BIN="$(find_mcumgr)"
+if [[ -z "$IMAGE" ]]; then
+    IMAGE="$(find_default_image)"
+fi
 
 if [[ ! -f "$IMAGE" ]]; then
     echo "Image not found: $IMAGE" >&2
-    echo "Build one first, for example: ./build.sh --h7 --ota" >&2
+    echo "Build one first, for example: ./build.sh" >&2
     exit 1
 fi
 


### PR DESCRIPTION
This updates the K2 build and flashing flow for #28.

The build wrappers now default to the H7 OTA sysbuild, keep --ota as an explicit no-op, and require --no-ota for a plain development build. F7 flags now fail clearly because F7 support is being sunset.

The OTA helpers now discover the signed image under build-h755-ota/*/zephyr/zephyr.signed.bin, so sibling worktrees and renamed checkouts do not break the default upload path. The README, Ethernet OTA guide, release matrix, and stale comments now document H7 and OTA as the supported path, with USB west flash reserved for first-time provisioning or recovery.

Validated with:
- ./build.sh --help
- ./build.sh --f7 exits with the sunset message
- pwsh -NoProfile -File ./build.ps1 --help
- pwsh -NoProfile -File ./build.ps1 --f7 exits with the sunset message
- bash -n build.sh tools/k2-ota.sh
- PowerShell parser check for build.ps1 and tools/k2-ota.ps1
- ./build.sh default OTA build succeeds and produces build-h755-ota/K2-Zephyr-issue28-build-docs/zephyr/zephyr.signed.bin