### PR TITLE
Add dimmable light PWM on D6/PA8 (TIM1_CH1)

### DIFF
--- a/PINOUT.md
+++ b/PINOUT.md
@@ -42,5 +42,16 @@
 
 ---
 
+## Light (Dimmable LED driver) - PWM
+| Function | Pin | Nucleo Label | Timer | Direction |
+|----------|-----|--------------|-------|-----------|
+| PWM      | PA8 | D6           | TIM1_CH1 | Output |
+
+**Frequency**: 1 kHz
+**Control**: brightness 0-255 from the command packet `light` byte → duty cycle.
+A single PWM signal drives the external LED driver that powers both light LEDs.
+
+---
+
 ## Notes
 - All pins are on STM32H755ZI (Nucleo-144 board).

--- a/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
+++ b/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
@@ -1,4 +1,5 @@
 #include "nucleo_h755zi_q_stm32h755xx_m7_partitions.overlay"
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 /* Enable USART6 for VESC communication
  * TX = PC6 (D1 on CN10 pin 2)
@@ -66,5 +67,30 @@
         com-invdir;
         com-sequential;
         prechargep = <0x22>;
+    };
+};
+
+/* Dimmable light output: TIM1_CH1 on D6/PA8 drives the external LED driver
+ * that powers both light LEDs from a single PWM signal.
+ * Prescaler is chosen so the 1 kHz auto-reload stays well within the 16-bit
+ * TIM1 range while leaving >>256 duty steps for smooth dimming.
+ */
+&timers1 {
+    st,prescaler = <128>;
+    status = "okay";
+};
+
+&pwm1 {
+    status = "okay";
+    pinctrl-0 = <&tim1_ch1_pa8>;
+    pinctrl-names = "default";
+};
+
+/ {
+    pwmleds {
+        compatible = "pwm-leds";
+        rov_light: rov_light {
+            pwms = <&pwm1 1 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
+        };
     };
 };

--- a/prj.conf
+++ b/prj.conf
@@ -66,6 +66,9 @@ CONFIG_NET_STATISTICS=y
 # ==================== GPIO & HARDWARE ====================
 # Enable GPIO (General Purpose Input/Output) for LED control
 CONFIG_GPIO=y
+# Enable PWM for the dimmable light output (TIM1_CH1 on D6/PA8 drives the
+# external LED driver feeding both light LEDs)
+CONFIG_PWM=y
 
 # ==================== DEBUGGING & DIAGNOSTICS ====================
 # Enable thread stack information for debugging

--- a/src/control.c
+++ b/src/control.c
@@ -1,5 +1,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/drivers/pwm.h>
 #include <string.h>
 #include "control.h"
 #include "pid/pid_controller.h"
@@ -10,6 +11,9 @@
 #include "vesc/vesc_uart_zephyr.h"
 
 LOG_MODULE_REGISTER(rov_control, LOG_LEVEL_INF);
+
+/* Dimmable light output (TIM1_CH1 / D6 / PA8 → external LED driver). */
+static const struct pwm_dt_spec light_pwm = PWM_DT_SPEC_GET(DT_NODELABEL(rov_light));
 
 /* ---------------------------------------------------------------------------
  * Configuration
@@ -333,8 +337,16 @@ static void stabilise(float out[6])
  * --------------------------------------------------------------------------- */
 static void rov_set_light(uint8_t brightness)
 {
-    if (brightness > 0) {
-        LOG_DBG("Light: %d%% (%d/255)", (brightness * 100) / 255, brightness);
+    if (!pwm_is_ready_dt(&light_pwm)) {
+        return;
+    }
+
+    /* Map 0..255 brightness onto 0..period duty cycle. */
+    uint32_t pulse = (uint32_t)(((uint64_t)light_pwm.period * brightness) / 255U);
+
+    int ret = pwm_set_pulse_dt(&light_pwm, pulse);
+    if (ret < 0) {
+        LOG_ERR("Failed to set light PWM (brightness %d): %d", brightness, ret);
     }
 }
 
@@ -439,9 +451,8 @@ static void rov_control_thread(void *arg1, void *arg2, void *arg3)
 
             /* Peripherals */
             k_mutex_lock(&pilot_mutex, K_FOREVER);
-            if (pilot.light > 0) {
-                rov_set_light(pilot.light);
-            }
+            /* Always update the light so brightness 0 turns the LEDs off. */
+            rov_set_light(pilot.light);
             if (pilot.manipulator > 0) {
                 rov_set_manipulator(pilot.manipulator);
             }
@@ -467,6 +478,13 @@ void rov_control_init(void)
     if (ret < 0) {
         LOG_ERR("Failed to initialize VESC UART: %d", ret);
         return;
+    }
+
+    /* Initialize the dimmable light PWM and start with the LEDs off */
+    if (!pwm_is_ready_dt(&light_pwm)) {
+        LOG_ERR("Light PWM device not ready");
+    } else if (pwm_set_pulse_dt(&light_pwm, 0) < 0) {
+        LOG_ERR("Failed to initialize light PWM to off");
     }
 
     /* Initialize all PID controllers (gains start at 0 → bypass mode) */


### PR DESCRIPTION
## What

`rov_set_light()` was a stub that only logged. This drives the external LED driver with real PWM:

- `prj.conf`: enable `CONFIG_PWM`.
- Board overlay: enable `TIM1` + `pwm1` (TIM1_CH1) on **D6/PA8**, add a `pwm-leds` consumer node `rov_light` (1 kHz).
- `control.c`: bind the PWM via `PWM_DT_SPEC_GET`, map the command packet's `light` byte (0–255) onto the duty cycle, init to off, and **always** update it each control cycle so brightness 0 fully turns the LEDs off.
- `PINOUT.md`: document the new light pin.

A single PWM signal drives the LED driver that powers both light LEDs (one channel — no protocol change; the command packet already carries the `light` byte).

## Pairs with

Topside PR `feature/light-control` (slider UI + `/api/lights`). This firmware PR can merge independently.

## Verification / reviewer please confirm

- ⚠️ Not built locally (no Zephyr workspace on the dev machine). **Please run `./build.ps1` / `./build.sh`.**
- Confirm the board's Arduino header maps **D6 → PA8** and that `tim1_ch1_pa8` / `&pwm1` / `&timers1` resolve in the pinned Zephyr 4.2 SoC dtsi.
- On hardware: brightness sweeps 0–100% smoothly and 0 turns the LEDs fully off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)