### PR TITLE
Fixed build issue regarding undeclared label for pwm1 in overlay.

### DIFF
--- a/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
+++ b/boards/nucleo_h755zi_q_stm32h755xx_m7.overlay
@@ -78,12 +78,12 @@
 &timers1 {
     st,prescaler = <128>;
     status = "okay";
-};
 
-&pwm1 {
-    status = "okay";
-    pinctrl-0 = <&tim1_ch1_pa8>;
-    pinctrl-names = "default";
+    pwm1: pwm {
+        status = "okay";
+        pinctrl-0 = <&tim1_ch1_pa8>;
+        pinctrl-names = "default";
+    };
 };
 
 / {


### PR DESCRIPTION
Tested IMU data recieved successfully and LED-light dimming functioning correctly. Only file changed was .overlay. 